### PR TITLE
Add deprecated status for endpoints

### DIFF
--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/Results.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/Results.java
@@ -22,6 +22,7 @@ public class Results {
     private Map<OperationKey, OperationResult> operations = new TreeMap<>();
     private Map<String, OperationResult> flatOperations = new TreeMap<>();
     private Map<OperationKey, Operation> missed = new TreeMap<>();
+    private Map<OperationKey, Operation> deprecated = new TreeMap<>();
     private Map<String, ConditionStatistics> conditionStatisticsMap = new HashMap<>();
     private Set<OperationKey> zeroCall = new HashSet<>();
 
@@ -70,6 +71,15 @@ public class Results {
     public Results setMissed(Map<OperationKey, Operation> missed) {
         this.missed = missed;
         return this;
+    }
+
+    public Results setDeprecated(Map<OperationKey, Operation> deprecated) {
+        this.deprecated = deprecated;
+        return this;
+    }
+
+    public Map<OperationKey, Operation> getDeprecated() {
+        return deprecated;
     }
 
     public GenerationStatistics getGenerationStatistics() {

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/postbuilder/ConditionStatisticsBuilder.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/postbuilder/ConditionStatisticsBuilder.java
@@ -33,9 +33,10 @@ public class ConditionStatisticsBuilder extends StatisticsOperationPostBuilder {
             case FULL:
                 coverageOperationMap.addFull(operation);
                 break;
-            case DEPRECATED:
-                coverageOperationMap.addDeprecated(operation);
-                break;
+        }
+
+        if (operationResult.getDeprecated()) {
+            coverageOperationMap.addDeprecated(operation);
         }
     }
 }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/postbuilder/ConditionStatisticsBuilder.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/postbuilder/ConditionStatisticsBuilder.java
@@ -33,6 +33,9 @@ public class ConditionStatisticsBuilder extends StatisticsOperationPostBuilder {
             case FULL:
                 coverageOperationMap.addFull(operation);
                 break;
+            case DEPRECATED:
+                coverageOperationMap.addDeprecated(operation);
+                break;
         }
     }
 }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/postbuilder/ConditionStatisticsBuilder.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/postbuilder/ConditionStatisticsBuilder.java
@@ -5,6 +5,7 @@ import com.github.viclovsky.swagger.coverage.core.results.Results;
 import com.github.viclovsky.swagger.coverage.core.results.builder.core.StatisticsOperationPostBuilder;
 import com.github.viclovsky.swagger.coverage.core.results.data.ConditionCounter;
 import com.github.viclovsky.swagger.coverage.core.results.data.CoverageOperationMap;
+import com.github.viclovsky.swagger.coverage.core.results.data.CoverageState;
 import com.github.viclovsky.swagger.coverage.core.results.data.OperationResult;
 
 public class ConditionStatisticsBuilder extends StatisticsOperationPostBuilder {
@@ -37,6 +38,11 @@ public class ConditionStatisticsBuilder extends StatisticsOperationPostBuilder {
 
         if (operationResult.getDeprecated()) {
             coverageOperationMap.addDeprecated(operation);
+            conditionCounter.incrementDeprecated();
+
+            if (operationResult.getState() == CoverageState.EMPTY) {
+                conditionCounter.incrementDeprecatedAndEmpty();
+            }
         }
     }
 }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/prebuilder/CoverageStatisticsBuilder.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/prebuilder/CoverageStatisticsBuilder.java
@@ -75,7 +75,7 @@ public class CoverageStatisticsBuilder extends StatisticsPreBuilder {
         mainCoverageData.forEach((key, value) -> {
             value.getConditions().stream().filter(Condition::isHasPostCheck).forEach(Condition::postCheck);
 
-            operations.put(key, new OperationResult(value.getConditions())
+            operations.put(key, new OperationResult(value.getConditions(), value.getOperation().isDeprecated())
                     .setProcessCount(value.getProcessCount())
                     .setDescription(value.getOperation().getDescription())
                     .setOperationKey(key)

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/prebuilder/CoverageStatisticsBuilder.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/prebuilder/CoverageStatisticsBuilder.java
@@ -30,6 +30,7 @@ public class CoverageStatisticsBuilder extends StatisticsPreBuilder {
 
     private Map<OperationKey, ConditionOperationCoverage> mainCoverageData;
     private Map<OperationKey, Operation> missed = new TreeMap<>();
+    private Map<OperationKey, Operation> deprecated = new TreeMap<>();
 
     @Override
     public CoverageStatisticsBuilder configure(Swagger swagger, List<ConditionRule> rules) {
@@ -81,6 +82,10 @@ public class CoverageStatisticsBuilder extends StatisticsPreBuilder {
                     .setOperationKey(key)
             );
 
+            if (value.getOperation().isDeprecated() != null && value.getOperation().isDeprecated()) {
+                deprecated.put(key, value.getOperation());
+            }
+
             value.getConditions().forEach(condition -> {
                         if (!conditionStatisticsMap.containsKey(condition.getType())) {
                             conditionStatisticsMap.put(condition.getType(), new ConditionStatistics());
@@ -92,6 +97,7 @@ public class CoverageStatisticsBuilder extends StatisticsPreBuilder {
 
         results.setOperations(operations)
                 .setMissed(missed)
+                .setDeprecated(deprecated)
                 .setConditionStatisticsMap(conditionStatisticsMap);
     }
 }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/ConditionCounter.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/ConditionCounter.java
@@ -4,6 +4,8 @@ public class ConditionCounter {
 
     private long all = 0;
     private long covered = 0;
+    private long deprecated = 0;
+    private long deprecatedAndEmpty = 0;
 
     public ConditionCounter updateAll(long count) {
         this.all = this.all + count;
@@ -12,6 +14,16 @@ public class ConditionCounter {
 
     public ConditionCounter updateCovered(long count) {
         this.covered = this.covered + count;
+        return this;
+    }
+
+    public ConditionCounter incrementDeprecated() {
+        this.deprecated = this.deprecated + 1;
+        return this;
+    }
+
+    public ConditionCounter incrementDeprecatedAndEmpty() {
+        this.deprecatedAndEmpty = this.deprecatedAndEmpty + 1;
         return this;
     }
 
@@ -31,6 +43,22 @@ public class ConditionCounter {
     public ConditionCounter setCovered(long covered) {
         this.covered = covered;
         return this;
+    }
+
+    public long getDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(long deprecated) {
+        this.deprecated = deprecated;
+    }
+
+    public long getDeprecatedAndEmpty() {
+        return deprecatedAndEmpty;
+    }
+
+    public void setDeprecatedAndEmpty(long deprecatedAndEmpty) {
+        this.deprecatedAndEmpty = deprecatedAndEmpty;
     }
 
     @Override

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/CoverageCounter.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/CoverageCounter.java
@@ -5,6 +5,7 @@ public class CoverageCounter {
     private long full = 0;
     private long party = 0;
     private long empty = 0;
+    private long deprecated = 0;
 
     public CoverageCounter incrementByState(CoverageState state) {
         switch (state) {
@@ -35,6 +36,13 @@ public class CoverageCounter {
     public CoverageCounter incrementEmpty() {
         this.all++;
         this.empty++;
+
+        return this;
+    }
+
+    public CoverageCounter incrementDeprecated() {
+        this.all++;
+        this.deprecated++;
 
         return this;
     }
@@ -75,6 +83,15 @@ public class CoverageCounter {
         return this;
     }
 
+    public long getDeprecated() {
+        return deprecated;
+    }
+
+    public CoverageCounter setDeprecated(long deprecated) {
+        this.deprecated = deprecated;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "CoverageCounter{" +
@@ -82,6 +99,7 @@ public class CoverageCounter {
                 ", full=" + full +
                 ", party=" + party +
                 ", empty=" + empty +
+                ", deprecated=" + deprecated +
                 '}';
     }
 }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/CoverageOperationMap.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/CoverageOperationMap.java
@@ -9,6 +9,7 @@ public class CoverageOperationMap {
     private Set<OperationKey> full = new HashSet<>();
     private Set<OperationKey> party = new HashSet<>();
     private Set<OperationKey> empty = new HashSet<>();
+    private Set<OperationKey> deprecated = new HashSet<>();
 
     protected CoverageCounter counter = new CoverageCounter();
 
@@ -27,6 +28,12 @@ public class CoverageOperationMap {
     public CoverageOperationMap addEmpty(OperationKey operation) {
         this.empty.add(operation);
         this.counter.incrementEmpty();
+        return this;
+    }
+
+    public CoverageOperationMap addDeprecated(OperationKey operation) {
+        this.deprecated.add(operation);
+        this.counter.incrementDeprecated();
         return this;
     }
 
@@ -54,6 +61,15 @@ public class CoverageOperationMap {
 
     public CoverageOperationMap setEmpty(Set<OperationKey> empty) {
         this.empty = empty;
+        return this;
+    }
+
+    public Set<OperationKey> getDeprecated() {
+        return deprecated;
+    }
+
+    public CoverageOperationMap setDeprecated(Set<OperationKey> deprecated) {
+        this.deprecated = deprecated;
         return this;
     }
 

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/CoverageState.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/CoverageState.java
@@ -3,5 +3,6 @@ package com.github.viclovsky.swagger.coverage.core.results.data;
 public enum CoverageState {
     FULL,
     PARTY,
-    EMPTY
+    EMPTY,
+    DEPRECATED
 }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/CoverageState.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/CoverageState.java
@@ -3,6 +3,5 @@ package com.github.viclovsky.swagger.coverage.core.results.data;
 public enum CoverageState {
     FULL,
     PARTY,
-    EMPTY,
-    DEPRECATED
+    EMPTY
 }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/OperationResult.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/OperationResult.java
@@ -15,13 +15,17 @@ public class OperationResult {
     private String description;
     private CoverageState state;
 
-    public OperationResult(List<Condition> conditions) {
+    public OperationResult(List<Condition> conditions, Boolean isDeprecated) {
         this.conditions = conditions;
         allConditionCount = conditions.size();
         coveredConditionCount = conditions.stream().filter(Condition::isCovered).count();
 
         if (coveredConditionCount == 0) {
-            state = CoverageState.EMPTY;
+            if (isDeprecated != null && isDeprecated) {
+                state = CoverageState.DEPRECATED;
+            } else {
+                state = CoverageState.EMPTY;
+            }
         } else {
             if (allConditionCount == coveredConditionCount) {
                 state = CoverageState.FULL;

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/OperationResult.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/OperationResult.java
@@ -20,12 +20,10 @@ public class OperationResult {
         allConditionCount = conditions.size();
         coveredConditionCount = conditions.stream().filter(Condition::isCovered).count();
 
-        if (coveredConditionCount == 0) {
-            if (isDeprecated != null && isDeprecated) {
-                state = CoverageState.DEPRECATED;
-            } else {
-                state = CoverageState.EMPTY;
-            }
+        if (isDeprecated != null && isDeprecated) {
+            state = CoverageState.DEPRECATED;
+        } else if (coveredConditionCount == 0) {
+            state = CoverageState.EMPTY;
         } else {
             if (allConditionCount == coveredConditionCount) {
                 state = CoverageState.FULL;

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/OperationResult.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/OperationResult.java
@@ -14,15 +14,15 @@ public class OperationResult {
     private long processCount;
     private String description;
     private CoverageState state;
+    private boolean deprecated;
 
     public OperationResult(List<Condition> conditions, Boolean isDeprecated) {
         this.conditions = conditions;
+        this.deprecated = (isDeprecated != null) ? isDeprecated : false;
         allConditionCount = conditions.size();
         coveredConditionCount = conditions.stream().filter(Condition::isCovered).count();
 
-        if (isDeprecated != null && isDeprecated) {
-            state = CoverageState.DEPRECATED;
-        } else if (coveredConditionCount == 0) {
+        if (coveredConditionCount == 0) {
             state = CoverageState.EMPTY;
         } else {
             if (allConditionCount == coveredConditionCount) {
@@ -96,5 +96,13 @@ public class OperationResult {
 
     public void setConditions(List<Condition> conditions) {
         this.conditions = conditions;
+    }
+
+    public boolean getDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(boolean isDeprecated) {
+        this.deprecated = isDeprecated;
     }
 }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/writer/LogResultsWriter.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/writer/LogResultsWriter.java
@@ -19,6 +19,8 @@ public class LogResultsWriter implements CoverageResultsWriter {
 
     @Override
     public void write(Results results) {
+        LOGGER.info("Deprecated coverage: ");
+        logOperationCoverage(results.getOperations(), results.getCoverageOperationMap().getDeprecated());
         LOGGER.info("Empty coverage: ");
         logOperationCoverage(results.getOperations(), results.getCoverageOperationMap().getEmpty());
         LOGGER.info("Partial coverage: ");
@@ -28,11 +30,13 @@ public class LogResultsWriter implements CoverageResultsWriter {
         logMissedCoverage(results.getMissed());
 
         DecimalFormat df = new DecimalFormat("###.###");
+        float deprecatedPercentage = (float) (results.getCoverageOperationMap().getDeprecated().size() * 100) / results.getOperations().size();
         float emptyPercentage = (float) (results.getCoverageOperationMap().getEmpty().size() * 100) / results.getOperations().size();
         float partialPercentage = (float) (results.getCoverageOperationMap().getParty().size() * 100) / results.getOperations().size();
         float fullPercentage = (float) (results.getCoverageOperationMap().getFull().size() * 100) / results.getOperations().size();
 
         LOGGER.info(String.format("Conditions: %s/%s", results.getConditionCounter().getCovered(), results.getConditionCounter().getAll()));
+        LOGGER.info("Deprecated coverage " + df.format(deprecatedPercentage) + " %");
         LOGGER.info("Empty coverage " + df.format(emptyPercentage) + " %");
         LOGGER.info("Partial coverage " + df.format(partialPercentage) + " %");
         LOGGER.info("Full coverage " + df.format(fullPercentage) + " %");

--- a/swagger-coverage-commandline/src/test/resources/swagger-coverage-output/two_coverage.json
+++ b/swagger-coverage-commandline/src/test/resources/swagger-coverage-output/two_coverage.json
@@ -5,7 +5,7 @@
   "consumes" : [ "application/json" ],
   "produces" : [ "" ],
   "paths" : {
-    "/pet/findByTags" : {
+    "/pet/findByStatus" : {
       "get" : {
         "parameters" : [ {
           "name": "tags",

--- a/swagger-coverage-commons/src/main/resources/message.en
+++ b/swagger-coverage-commons/src/main/resources/message.en
@@ -15,6 +15,7 @@ operations.partial=Partial
 operations.empty=Empty
 operations.no_call=No call
 operations.missed=Missed
+operations.deprecated=Deprecated
 
 summary.operations=Operations coverage summary
 summary.operations.all=All operations

--- a/swagger-coverage-commons/src/main/resources/message.en
+++ b/swagger-coverage-commons/src/main/resources/message.en
@@ -8,6 +8,7 @@ common.state.full=Full
 common.state.partial=Partial
 common.state.empty=Empty
 common.state.no_call=No call
+common.state.deprecated=Deprecated
 
 operations.all=All
 operations.full=Full

--- a/swagger-coverage-commons/src/main/resources/message.ru
+++ b/swagger-coverage-commons/src/main/resources/message.ru
@@ -8,6 +8,7 @@ common.state.full=Полностью
 common.state.partial=Частично
 common.state.empty=Не покрыто
 common.state.no_call=Пропущено
+common.state.deprecated=Не используется
 
 operations.all=Все
 operations.full=Полностью

--- a/swagger-coverage-commons/src/main/resources/message.ru
+++ b/swagger-coverage-commons/src/main/resources/message.ru
@@ -15,6 +15,7 @@ operations.partial=Частично
 operations.empty=Не покрыто
 operations.no_call=Пропущено
 operations.missed=Лишние запросы
+operations.deprecated=Не используются
 
 summary.operations=Сводка по методам
 summary.operations.all=Всего

--- a/swagger-coverage-commons/src/main/resources/report.ftl
+++ b/swagger-coverage-commons/src/main/resources/report.ftl
@@ -129,6 +129,12 @@
                                 ${i18["operations.missed"]}: ${data.missed?size}
                             </a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link" id="deprecated-tab" data-toggle="tab" href="#deprecated" role="tab"
+                               aria-controls="deprecated" aria-selected="false">
+                                ${i18["operations.deprecated"]}: ${data.coverageOperationMap.deprecated?size}
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>
@@ -155,6 +161,9 @@
                         </div>
                         <div class="tab-pane fade" id="missed" role="tabpanel" aria-labelledby="missed-tab">
                             <@operations.list coverage=data.missed prefix="missed"/>
+                        </div>
+                        <div class="tab-pane fade" id="deprecated" role="tabpanel" aria-labelledby="deprecated-tab">
+                            <@condition.list coverage=data.coverageOperationMap.deprecated prefix="deprecated"/>
                         </div>
                     </div>
                 </div>

--- a/swagger-coverage-commons/src/main/resources/report.ftl
+++ b/swagger-coverage-commons/src/main/resources/report.ftl
@@ -132,7 +132,7 @@
                         <li class="nav-item">
                             <a class="nav-link" id="deprecated-tab" data-toggle="tab" href="#deprecated" role="tab"
                                aria-controls="deprecated" aria-selected="false">
-                                ${i18["operations.deprecated"]}: ${data.coverageOperationMap.deprecated?size}
+                                ${i18["operations.deprecated"]}: ${data.deprecated?size}
                             </a>
                         </li>
                     </ul>
@@ -163,7 +163,7 @@
                             <@operations.list coverage=data.missed prefix="missed"/>
                         </div>
                         <div class="tab-pane fade" id="deprecated" role="tabpanel" aria-labelledby="deprecated-tab">
-                            <@condition.list coverage=data.coverageOperationMap.deprecated prefix="deprecated"/>
+                            <@operations.list coverage=data.deprecated prefix="deprecated"/>
                         </div>
                     </div>
                 </div>

--- a/swagger-coverage-commons/src/main/resources/ui.ftl
+++ b/swagger-coverage-commons/src/main/resources/ui.ftl
@@ -112,9 +112,6 @@
             <#case "EMPTY">
                 <span class="badge badge-danger">${i18["common.state.empty"]}</span>
                 <#break>
-            <#case "DEPRECATED">
-                <span class="badge badge-danger">${i18["common.state.deprecated"]}</span>
-                <#break>
             <#default>
         </#switch>
     </#if>

--- a/swagger-coverage-commons/src/main/resources/ui.ftl
+++ b/swagger-coverage-commons/src/main/resources/ui.ftl
@@ -112,6 +112,9 @@
             <#case "EMPTY">
                 <span class="badge badge-danger">${i18["common.state.empty"]}</span>
                 <#break>
+            <#case "DEPRECATED">
+                <span class="badge badge-danger">${i18["common.state.deprecated"]}</span>
+                <#break>
             <#default>
         </#switch>
     </#if>


### PR DESCRIPTION
Sometimes endpoints in OpenAPI can be marked as deprecated and in report these endpoints should not get in the "empty" category