### PR TITLE
Exclude deprecated endpoints from final coverage results

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,32 @@ You can setup next options:
 }
 ````
 
+#### Excluding deprecated operations from the coverage report statistic
+This rule is created for cases when you don't want to measure coverage of deprecated operations, but only for actual ones. <br>
+If an operation is deprecated then it will be excluded from *Full*, *Partial*, and *Empty* categories and won't affect the "Operations coverage summary"
+
+Options for this rule are placed in "*exclude-deprecated*" subsection in *rules* sections.
+
+You can set up next options:
+
+**enable** - *true/false*. <br>
+By default, this rule is not enabled. Add it to the config file with *true* value to enable this rule, like in the example below:
+
+````
+{
+  "rules" : {
+
+    ....
+
+    "exclude-deprecated" : {
+      "enable" : true
+    }
+  },
+
+   ....
+}
+````
+
 If you need you can add your rules for generation of conditions. So, please, send your PRs.
 
 ## Result writer configuration

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/configuration/Configuration.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/configuration/Configuration.java
@@ -63,6 +63,10 @@ public class Configuration {
         return this;
     }
 
+    public RuleConfigurationOptions getOption(String optionKey) {
+        return this.options.getRules().get(optionKey);
+    }
+
     public Configuration setDefaultRules(List<ConditionRule> defaultRules) {
         this.defaultRules = defaultRules;
         return this;

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/generator/Generator.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/generator/Generator.java
@@ -42,10 +42,10 @@ public class Generator {
         Results result = new Results();
 
         statisticsBuilders.stream().filter(StatisticsBuilder::isPreBuilder).forEach(
-                statisticsBuilder -> statisticsBuilder.build(result));
+                statisticsBuilder -> statisticsBuilder.build(result, configuration));
 
         statisticsBuilders.stream().filter(StatisticsBuilder::isPostBuilder).forEach(
-                statisticsBuilder -> statisticsBuilder.build(result));
+                statisticsBuilder -> statisticsBuilder.build(result, configuration));
 
         configuration.getConfiguredResultsWriters().forEach(writer -> writer.write(result));
     }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/core/StatisticsBuilder.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/core/StatisticsBuilder.java
@@ -1,5 +1,6 @@
 package com.github.viclovsky.swagger.coverage.core.results.builder.core;
 
+import com.github.viclovsky.swagger.coverage.configuration.Configuration;
 import com.github.viclovsky.swagger.coverage.configuration.options.ConfigurationOptions;
 import com.github.viclovsky.swagger.coverage.core.results.Results;
 import com.github.viclovsky.swagger.coverage.core.rule.core.ConditionRule;
@@ -26,7 +27,7 @@ public abstract class StatisticsBuilder {
 
     public abstract StatisticsBuilder configure(Swagger swagger, List<ConditionRule> rules);
 
-    public abstract void build(Results results);
+    public abstract void build(Results results, Configuration configuration);
 
     public abstract boolean isPreBuilder();
 

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/core/StatisticsOperationPostBuilder.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/core/StatisticsOperationPostBuilder.java
@@ -1,6 +1,7 @@
 package com.github.viclovsky.swagger.coverage.core.results.builder.core;
 
 
+import com.github.viclovsky.swagger.coverage.configuration.Configuration;
 import com.github.viclovsky.swagger.coverage.core.model.OperationKey;
 import com.github.viclovsky.swagger.coverage.core.results.Results;
 import com.github.viclovsky.swagger.coverage.core.results.data.OperationResult;
@@ -17,7 +18,7 @@ public abstract class StatisticsOperationPostBuilder extends StatisticsPostBuild
     }
 
     @Override
-    public void build(Results results) {
+    public void build(Results results, Configuration configuration) {
         results.getOperations().forEach(this::buildOperation);
         buildResult(results);
     }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/postbuilder/ConfigurationStatisticsBuilder.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/postbuilder/ConfigurationStatisticsBuilder.java
@@ -3,6 +3,7 @@ package com.github.viclovsky.swagger.coverage.core.results.builder.postbuilder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.viclovsky.swagger.coverage.CommandLine;
+import com.github.viclovsky.swagger.coverage.configuration.Configuration;
 import com.github.viclovsky.swagger.coverage.core.results.Results;
 import com.github.viclovsky.swagger.coverage.core.results.builder.core.StatisticsBuilder;
 import com.github.viclovsky.swagger.coverage.core.results.builder.core.StatisticsPostBuilder;
@@ -23,7 +24,7 @@ public class ConfigurationStatisticsBuilder extends StatisticsPostBuilder {
     }
 
     @Override
-    public void build(Results results) {
+    public void build(Results results, Configuration configuration) {
         ObjectMapper mapper = new ObjectMapper();
         String prettyConfiguration = "";
         try {

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/prebuilder/CoverageStatisticsBuilder.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/prebuilder/CoverageStatisticsBuilder.java
@@ -1,6 +1,7 @@
 package com.github.viclovsky.swagger.coverage.core.results.builder.prebuilder;
 
 
+import com.github.viclovsky.swagger.coverage.configuration.Configuration;
 import com.github.viclovsky.swagger.coverage.core.generator.OperationConditionGenerator;
 import com.github.viclovsky.swagger.coverage.core.generator.SwaggerSpecificationProcessor;
 import com.github.viclovsky.swagger.coverage.core.model.Condition;
@@ -69,14 +70,14 @@ public class CoverageStatisticsBuilder extends StatisticsPreBuilder {
     }
 
     @Override
-    public void build(Results results) {
+    public void build(Results results, Configuration configuration) {
         Map<OperationKey, OperationResult> operations = new TreeMap<>();
         Map<String, ConditionStatistics> conditionStatisticsMap = new HashMap<>();
 
         mainCoverageData.forEach((key, value) -> {
             value.getConditions().stream().filter(Condition::isHasPostCheck).forEach(Condition::postCheck);
 
-            operations.put(key, new OperationResult(value.getConditions(), value.getOperation().isDeprecated())
+            operations.put(key, new OperationResult(configuration, value.getConditions(), value.getOperation().isDeprecated())
                     .setProcessCount(value.getProcessCount())
                     .setDescription(value.getOperation().getDescription())
                     .setOperationKey(key)

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/prebuilder/GenerationStatisticsBuilder.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/builder/prebuilder/GenerationStatisticsBuilder.java
@@ -1,6 +1,7 @@
 package com.github.viclovsky.swagger.coverage.core.results.builder.prebuilder;
 
 import com.github.viclovsky.swagger.coverage.CommandLine;
+import com.github.viclovsky.swagger.coverage.configuration.Configuration;
 import com.github.viclovsky.swagger.coverage.core.results.Results;
 import com.github.viclovsky.swagger.coverage.core.results.builder.core.StatisticsPreBuilder;
 import com.github.viclovsky.swagger.coverage.core.results.data.GenerationStatistics;
@@ -54,7 +55,7 @@ public class GenerationStatisticsBuilder extends StatisticsPreBuilder {
     }
 
     @Override
-    public void build(Results results) {
+    public void build(Results results, Configuration configuration) {
         final long duration = System.currentTimeMillis() - startTime;
         final String resultDateDuration = DateTimeUtil.formatDate(minResultTime.toInstant())
                 + " - "

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/CoverageState.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/CoverageState.java
@@ -3,5 +3,6 @@ package com.github.viclovsky.swagger.coverage.core.results.data;
 public enum CoverageState {
     FULL,
     PARTY,
-    EMPTY
+    EMPTY,
+    DEPRECATED,
 }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/OperationResult.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/OperationResult.java
@@ -22,7 +22,9 @@ public class OperationResult {
         allConditionCount = conditions.size();
         coveredConditionCount = conditions.stream().filter(Condition::isCovered).count();
 
-        if (coveredConditionCount == 0) {
+        if (this.deprecated) {
+            state = CoverageState.DEPRECATED;
+        } else if (coveredConditionCount == 0) {
             state = CoverageState.EMPTY;
         } else {
             if (allConditionCount == coveredConditionCount) {

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/OperationResult.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/OperationResult.java
@@ -1,5 +1,6 @@
 package com.github.viclovsky.swagger.coverage.core.results.data;
 
+import com.github.viclovsky.swagger.coverage.configuration.Configuration;
 import com.github.viclovsky.swagger.coverage.core.model.Condition;
 import com.github.viclovsky.swagger.coverage.core.model.OperationKey;
 
@@ -7,6 +8,7 @@ import java.util.List;
 
 public class OperationResult {
 
+    private boolean excludeDeprecated;
     private OperationKey operationKey;
     private List<Condition> conditions;
     private long allConditionCount;
@@ -16,13 +18,19 @@ public class OperationResult {
     private CoverageState state;
     private boolean deprecated;
 
-    public OperationResult(List<Condition> conditions, Boolean isDeprecated) {
+    public OperationResult(Configuration configuration, List<Condition> conditions, Boolean isDeprecated) {
         this.conditions = conditions;
         this.deprecated = (isDeprecated != null) ? isDeprecated : false;
         allConditionCount = conditions.size();
         coveredConditionCount = conditions.stream().filter(Condition::isCovered).count();
 
-        if (this.deprecated) {
+        try {
+            excludeDeprecated = configuration.getOption("exclude-deprecated").isEnable();
+        } catch (NullPointerException e) {
+            excludeDeprecated = false;
+        }
+
+        if (this.deprecated && excludeDeprecated) {
             state = CoverageState.DEPRECATED;
         } else if (coveredConditionCount == 0) {
             state = CoverageState.EMPTY;

--- a/swagger-coverage-commandline/src/test/resources/full_configuration.json
+++ b/swagger-coverage-commandline/src/test/resources/full_configuration.json
@@ -18,6 +18,9 @@
     },
     "enum-another-value": {
       "enable": true
+    },
+    "exclude-deprecated" : {
+      "enable" : true
     }
   },
   "writers": {


### PR DESCRIPTION
CoverageState.DEPRECATED is added to ignore deprecated endpoints and not to add them to the final coverage results.
Without taking them into account the coverage statistic looks more clear.
The final statistic was incorrectly calculated. 
For example: 14 of 20 is 70% (not 66.667%)

## Before
![before](https://user-images.githubusercontent.com/8066700/106723706-11424e00-6610-11eb-9c12-1dbf629b709d.png)
## After
![after](https://user-images.githubusercontent.com/8066700/106723715-130c1180-6610-11eb-92cc-cff12a0bc58f.png)