### PR TITLE
Check to make sure property schema name is non-null

### DIFF
--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/predicate/PropertyConditionPredicate.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/predicate/PropertyConditionPredicate.java
@@ -3,6 +3,7 @@ package com.github.viclovsky.swagger.coverage.core.predicate;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -28,8 +29,9 @@ public abstract class PropertyConditionPredicate extends ConditionPredicate {
                 .filter(o -> mediaTypeName.equals(o.getKey()))
                 .map(o -> o.getValue().getSchema())
                 .filter(Objects::nonNull)
-                .flatMap(o -> (Stream<Schema>) o.getProperties().values().stream())
-                .filter(o -> propertyName.equals(o.getName()))
+                .flatMap(o -> (Stream<Map.Entry<String, Schema>>) o.getProperties().entrySet().stream())
+                .filter(o -> propertyName.equals(o.getKey()))
+                .map(o -> o.getValue())
                 .findFirst();
         return check(schema);
     }
@@ -38,7 +40,9 @@ public abstract class PropertyConditionPredicate extends ConditionPredicate {
         return propertyName;
     }
 
-    public String getMediaTypeName() { return mediaTypeName; }
+    public String getMediaTypeName() {
+        return mediaTypeName;
+    }
 
     public PropertyConditionPredicate setPropertyName(String propertyName) {
         this.propertyName = propertyName;

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/predicate/PropertyConditionPredicate.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/predicate/PropertyConditionPredicate.java
@@ -25,11 +25,11 @@ public abstract class PropertyConditionPredicate extends ConditionPredicate {
         }
         Optional<Schema> schema = operation.getRequestBody().getContent().entrySet()
                 .stream()
-                .filter(o -> o.getKey().equals(mediaTypeName))
+                .filter(o -> mediaTypeName.equals(o.getKey()))
                 .map(o -> o.getValue().getSchema())
                 .filter(Objects::nonNull)
                 .flatMap(o -> (Stream<Schema>) o.getProperties().values().stream())
-                .filter(o -> o.getName().equals(propertyName))
+                .filter(o -> propertyName.equals(o.getName()))
                 .findFirst();
         return check(schema);
     }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyConditionRule.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyConditionRule.java
@@ -8,7 +8,9 @@ import io.swagger.v3.oas.models.media.Schema;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -28,15 +30,15 @@ public abstract class PropertyConditionRule extends ConditionRule {
 
     private Stream<Condition> processMediaType(String mediaTypeName, MediaType mediaType) {
         if (mediaType.getSchema() != null && mediaType.getSchema().getProperties() != null) {
-            return ((Collection<Schema>) mediaType.getSchema().getProperties().values())
+            return ((Set<Map.Entry<String, Schema>>) mediaType.getSchema().getProperties().entrySet())
                     .stream()
-                    .map(s -> processProperty(mediaTypeName, s))
+                    .map(s -> processProperty(mediaTypeName, s.getKey(), s.getValue()))
                     .filter(Objects::nonNull);
         } else {
             return null;
         }
     }
 
-    protected abstract Condition processProperty(String mediaTypeName, Schema schema);
+    protected abstract Condition processProperty(String mediaTypeName, String name, Schema schema);
 
 }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyEnumAllValuesRule.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyEnumAllValuesRule.java
@@ -11,14 +11,14 @@ import java.util.List;
 public class PropertyEnumAllValuesRule extends PropertyConditionRule {
 
     @Override
-    protected Condition processProperty(String mediaTypeName, Schema schema) {
+    protected Condition processProperty(String mediaTypeName, String name, Schema schema) {
         List<String> enums = SwaggerSpecificationProcessor.extractEnum(schema);
-        if (schema != null && schema.getName() != null && mediaTypeName != null
+        if (schema != null && name != null && mediaTypeName != null
                 && enums != null && !enums.isEmpty()) {
             return new SinglePredicateCondition(
-                    String.format("«%s» contains all values from enum %s", schema.getName(), enums),
+                    String.format("«%s» contains all values from enum %s", name, enums),
                     "",
-                    new PropertyValueConditionPredicate(mediaTypeName, schema.getName(), enums)
+                    new PropertyValueConditionPredicate(mediaTypeName, name, enums)
             );
         }
         return null;

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyEnumAllValuesRule.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyEnumAllValuesRule.java
@@ -13,7 +13,8 @@ public class PropertyEnumAllValuesRule extends PropertyConditionRule {
     @Override
     protected Condition processProperty(String mediaTypeName, Schema schema) {
         List<String> enums = SwaggerSpecificationProcessor.extractEnum(schema);
-        if (mediaTypeName != null && enums != null && !enums.isEmpty()) {
+        if (schema != null && schema.getName() != null && mediaTypeName != null
+                && enums != null && !enums.isEmpty()) {
             return new SinglePredicateCondition(
                     String.format("«%s» contains all values from enum %s", schema.getName(), enums),
                     "",

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyNotEmptyRule.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyNotEmptyRule.java
@@ -8,12 +8,12 @@ import io.swagger.v3.oas.models.media.Schema;
 public class PropertyNotEmptyRule extends PropertyConditionRule {
 
     @Override
-    protected Condition processProperty(String mediaTypeName, Schema schema) {
-        if (schema != null && schema.getName() != null && mediaTypeName != null) {
+    protected Condition processProperty(String mediaTypeName, String name, Schema schema) {
+        if (schema != null && name != null && mediaTypeName != null) {
             return new SinglePredicateCondition(
-                    String.format("«%s» is not empty", schema.getName()),
+                    String.format("«%s» is not empty", name),
                     "",
-                    new DefaultPropertyConditionPredicate(mediaTypeName, schema.getName(), false)
+                    new DefaultPropertyConditionPredicate(mediaTypeName, name, false)
             );
         }
         return null;

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyNotEmptyRule.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyNotEmptyRule.java
@@ -9,7 +9,7 @@ public class PropertyNotEmptyRule extends PropertyConditionRule {
 
     @Override
     protected Condition processProperty(String mediaTypeName, Schema schema) {
-        if (schema != null && mediaTypeName != null) {
+        if (schema != null && schema.getName() != null && mediaTypeName != null) {
             return new SinglePredicateCondition(
                     String.format("«%s» is not empty", schema.getName()),
                     "",

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyNotOnlyEnumValuesRule.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyNotOnlyEnumValuesRule.java
@@ -13,7 +13,8 @@ public class PropertyNotOnlyEnumValuesRule extends PropertyConditionRule {
     @Override
     protected Condition processProperty(String mediaTypeName, Schema schema) {
         List<String> enums = SwaggerSpecificationProcessor.extractEnum(schema);
-        if (enums != null && !enums.isEmpty()) {
+        if (schema != null && schema.getName() != null && mediaTypeName != null
+                && enums != null && !enums.isEmpty()) {
             return new SinglePredicateCondition(
                     String.format("«%s» contains all values from enum %s", schema.getName(), enums),
                     "",

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyNotOnlyEnumValuesRule.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/rule/body/PropertyNotOnlyEnumValuesRule.java
@@ -11,14 +11,14 @@ import java.util.List;
 public class PropertyNotOnlyEnumValuesRule extends PropertyConditionRule {
 
     @Override
-    protected Condition processProperty(String mediaTypeName, Schema schema) {
+    protected Condition processProperty(String mediaTypeName, String name, Schema schema) {
         List<String> enums = SwaggerSpecificationProcessor.extractEnum(schema);
-        if (schema != null && schema.getName() != null && mediaTypeName != null
+        if (schema != null && name != null && mediaTypeName != null
                 && enums != null && !enums.isEmpty()) {
             return new SinglePredicateCondition(
-                    String.format("«%s» contains all values from enum %s", schema.getName(), enums),
+                    String.format("«%s» contains all values from enum %s", name, enums),
                     "",
-                    new PropertyValueNotOnlyConditionPredicate(mediaTypeName, schema.getName(), enums)
+                    new PropertyValueNotOnlyConditionPredicate(mediaTypeName, name, enums)
             );
         }
         return null;


### PR DESCRIPTION
Check that the schema name is non-null in the Rule so that the rule is not incorrectly added.

In the v3 model the schema.getName() is returning null for properties (what was v2 FormParameter).  Instead, we need to check the key of the getProperties() map.