### PR TITLE
Issue 84: Deprecated endpoints include in coverageOperationMap.counter.all

### DIFF
--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/CoverageCounter.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/results/data/CoverageCounter.java
@@ -41,7 +41,6 @@ public class CoverageCounter {
     }
 
     public CoverageCounter incrementDeprecated() {
-        this.all++;
         this.deprecated++;
 
         return this;


### PR DESCRIPTION
https://github.com/viclovsky/swagger-coverage/issues/84