### PR TITLE
Fix locale and encoding error which affected the html report and add numberFormat option to html writer

### DIFF
--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/configuration/ConfigurationBuilder.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/configuration/ConfigurationBuilder.java
@@ -70,8 +70,7 @@ public class ConfigurationBuilder {
                         switch (key) {
                             case "html":
                                 configuredResultsWriters.add(
-                                        new HtmlReportResultsWriter(value.getLocale(), value.getFilename(),
-                                                value.getCustomTemplatePath())
+                                        new HtmlReportResultsWriter(value)
                                 );
                                 break;
                             case "LOGGER":

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/configuration/options/ResultsWriterOptions.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/configuration/options/ResultsWriterOptions.java
@@ -4,6 +4,7 @@ public class ResultsWriterOptions {
     private String filename;
     private String locale = "en";
     private String customTemplatePath;
+    private String numberFormat = "0.###";
 
     public String getFilename() {
         return filename;
@@ -29,6 +30,7 @@ public class ResultsWriterOptions {
                 ", filename='" + filename + '\'' +
                 ", locale='" + locale + '\'' +
                 ", customTemplatePath='" + customTemplatePath + '\'' +
+                ", numberFormat='" + numberFormat + '\'' +
                 '}';
     }
 
@@ -39,5 +41,12 @@ public class ResultsWriterOptions {
 
     public String getCustomTemplatePath() {
         return customTemplatePath;
+    }
+
+    public String getNumberFormat() {return numberFormat;}
+
+    public ResultsWriterOptions setNumberFormat(String numberFormat){
+        this.numberFormat = numberFormat;
+        return this;
     }
 }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/writer/HtmlReportResultsWriter.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/writer/HtmlReportResultsWriter.java
@@ -26,6 +26,10 @@ public class HtmlReportResultsWriter implements CoverageResultsWriter {
     private String numberFormat = "0.###";
 
     public HtmlReportResultsWriter() {
+        options = new ResultsWriterOptions()
+                .setFilename(filename)
+                .setLocale(localeCode)
+                .setNumberFormat(numberFormat);
     }
 
     public HtmlReportResultsWriter(ResultsWriterOptions options){

--- a/swagger-coverage-commandline/src/test/java/com/github/viclovsky/swagger/coverage/CustomReportTemplateTest.java
+++ b/swagger-coverage-commandline/src/test/java/com/github/viclovsky/swagger/coverage/CustomReportTemplateTest.java
@@ -41,6 +41,7 @@ public class CustomReportTemplateTest {
         customReportOptions.put("html", new ResultsWriterOptions()
                 .setFilename("custom-template-report.html")
                 .setLocale("en")
+                .setNumberFormat("0.###")
                 .setCustomTemplatePath(Paths.get(res.toURI()).toFile().getAbsolutePath()));
         ConfigurationOptions configurationOptions = new ConfigurationOptions().setWriters(customReportOptions);
         File testConfigurationFile = File.createTempFile("customTemplate", ".json");

--- a/swagger-coverage-commons/src/main/java/com/github/viclovsky/swagger/coverage/utils/FreemarkerUtils.java
+++ b/swagger-coverage-commons/src/main/java/com/github/viclovsky/swagger/coverage/utils/FreemarkerUtils.java
@@ -27,7 +27,7 @@ public final class FreemarkerUtils {
     }
 
     public static String processTemplate(final String path, final Object object) {
-        return processTemplate(path,"en",object);
+        return processTemplate(path,"en", "0.###", object);
     }
 
     private static String proccessTemplate(Configuration configuration, String locale, String templateName,
@@ -48,22 +48,24 @@ public final class FreemarkerUtils {
         }
     }
 
-    public static String processTemplate(final String path, String locale, final Object object) {
+    public static String processTemplate(final String path, String locale, String numberFormat, final Object object) {
         final Configuration configuration = new Configuration(Configuration.VERSION_2_3_28);
 
         configuration.setClassForTemplateLoading(FreemarkerUtils.class, "/");
         configuration.setDefaultEncoding("UTF-8");
+        configuration.setNumberFormat(numberFormat);
 
         return proccessTemplate(configuration, locale, path, object);
     }
 
-    public static String processCustomTemplate(final String customTemplatePath, String locale, Object object)
+    public static String processCustomTemplate(final String customTemplatePath, String locale, String numberFormat, Object object)
             throws IOException {
         File template = new File(customTemplatePath);
         final Configuration configuration = new Configuration(Configuration.VERSION_2_3_28);
 
         configuration.setTemplateLoader(new FileTemplateLoader(template.getParentFile()));
         configuration.setDefaultEncoding("UTF-8");
+        configuration.setNumberFormat(numberFormat);
         return proccessTemplate(configuration, locale, template.getName(), object);
     }
 

--- a/swagger-coverage-commons/src/main/resources/ui.ftl
+++ b/swagger-coverage-commons/src/main/resources/ui.ftl
@@ -14,7 +14,7 @@
         <div class="progress" style="height: ${height}px;">
             <div
                     class="progress-bar ${bgStyle}" role="progressbar"
-                    style="width: ${percentValue}%"
+                    style="width: ${percentValue?c}%"
                     aria-valuenow="${current}"
                     aria-valuemin="0"
                     aria-valuemax="${full}">
@@ -47,6 +47,9 @@
 
 <#macro coverageBadget counter>
     <#if counter.all gt 0>
+        <#assign fullValue = counter.full * 100 / counter.all>
+        <#assign partlyValue = counter.party * 100 / counter.all>
+        <#assign emptyValue = counter.empty * 100 / counter.all>
         <div class="card" style="margin-bottom: 16px;">
             <div class="card-body">
                 <div class="row">
@@ -71,21 +74,21 @@
                         <div class="progress" style="height: 16px;">
                             <div
                                     class="progress-bar bg-success" role="progressbar"
-                                    style="width: ${counter.full * 100 / counter.all}%"
+                                    style="width: ${fullValue?c}%"
                                     aria-valuenow="${counter.full}"
                                     aria-valuemin="0"
                                     aria-valuemax="${counter.all}">
                             </div>
                             <div
                                     class="progress-bar bg-warning" role="progressbar"
-                                    style="width: ${counter.party * 100 / counter.all}%"
+                                    style="width: ${partlyValue?c}%"
                                     aria-valuenow="${counter.party}"
                                     aria-valuemin="0"
                                     aria-valuemax="${counter.all}">
                             </div>
                             <div
                                     class="progress-bar bg-danger" role="progressbar"
-                                    style="width: ${counter.empty * 100 / counter.all}%"
+                                    style="width: ${emptyValue?c}%"
                                     aria-valuenow="${counter.empty}"
                                     aria-valuemin="0"
                                     aria-valuemax="${counter.all}">


### PR DESCRIPTION
### Fix 1: 
Whenever a progress bar is fed a decimal number, it is not correctly displayed with locales that use any other decimal separators than '.' -> in German e.g a decimal number is separated with a comma (2,34). 
In the ftl files, whenver a number is used within a progress bar element, the c- built in is now included to always guarantee the use of a number that is in computer standard format.

![Screenshot 2021-11-05 154211](https://user-images.githubusercontent.com/42011482/140528736-34230b3a-914a-46d4-802c-a30948f65bd8.png)

### Fix 2: 
On Systems that use a different encoding than UTF-8, some of the special symbols, like the one used to enclose the parameters, are not displayed correctly. Therefore, the `getBytes()` method of the htmlReport String explicitly uses UTF-8 now.

![Screenshot 2021-11-05 154233](https://user-images.githubusercontent.com/42011482/140528763-5f586535-cd71-4c13-a374-cdd4161b40a3.png)

### Addition:  
To customize the way numbers are presented in the report, the "numberFormat" option has been added to the possible configurations for the html writer. This way, the format can be specified using [Freemarkers extended java decimal format](https://freemarker.apache.org/docs/ref_builtins_number.html#topic.extendedJavaDecimalFormat)
The user can now for example choose to only have two digits behind the decimal separator (0.##).