### PR TITLE
Issue 93: Fix dependency resolving problem for gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,10 @@ configure(subprojects) {
         (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:none", "-quiet")
     }
 
+    tasks.withType<GenerateModuleMetadata> {
+        enabled = false
+    }
+
     artifacts.add("archives", sourceJar)
     artifacts.add("archives", javadocJar)
 


### PR DESCRIPTION
After some digging, I found the solution for #93.
With the change in gradle versions (#86), the generated metadata POM included a [special marker](https://docs.gradle.org/current/userguide/declaring_dependencies.html#sub:supported-md-pom), telling gradle to instead use the gradle module metadata, which does not include the dependency version numbers configured with the used dependency-management plugin. I therefore disabled the generation of said gradle module metadata files, so that the POM File is evaluated as expected.
