### PR TITLE
Enable support for Web URLs to parse the swagger specification directly from a server

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ You can setup next options:
 
 **filename** - filename for html report.
 
+**numberFormat** - [Extended Java decimal format](https://freemarker.apache.org/docs/ref_builtins_number.html#topic.extendedJavaDecimalFormat) to control how numbers are displayed in the report.
+
 ````
 {
   ....
@@ -203,7 +205,8 @@ You can setup next options:
   "writers": {
       "html": {
         "locale": "ru",
-        "filename":"report.html"
+        "filename":"report.html",
+        "numberFormat": "0.##"
       }
   }
 }

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Here is help of unzip swagger-commandline
 
   Options:
   * -s, --spec
-      Path to swagger specification.
+      Path to local or URL to remote swagger specification.
   * -i, --input
       Path to folder with generated files with coverage.
     -c, --configuration

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/generator/Generator.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/generator/Generator.java
@@ -12,6 +12,7 @@ import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +21,7 @@ public class Generator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Generator.class);
 
-    private Path specPath;
+    private URI specPath;
     private Path inputPath;
 
     private Path configurationPath;
@@ -30,7 +31,7 @@ public class Generator {
     private List<StatisticsBuilder> statisticsBuilders = new ArrayList<>();
 
     public void run() {
-        SwaggerParseResult parsed = parser.readLocation(getSpecPath().toUri().toString(), null, null);
+        SwaggerParseResult parsed = parser.readLocation(specPath.toString(), null, null);
         parsed.getMessages().forEach(LOGGER::info);
         OpenAPI spec = parsed.getOpenAPI();
 
@@ -61,11 +62,11 @@ public class Generator {
                 builder.add(path.toString()).add(spec));
     }
 
-    public Path getSpecPath() {
+    public URI getSpecPath() {
         return specPath;
     }
 
-    public Generator setSpecPath(Path specPath) {
+    public Generator setSpecPath(URI specPath) {
         this.specPath = specPath;
         return this;
     }

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/option/MainOptions.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/option/MainOptions.java
@@ -2,6 +2,7 @@ package com.github.viclovsky.swagger.coverage.option;
 
 import com.beust.jcommander.Parameter;
 
+import java.net.URI;
 import java.nio.file.Path;
 
 public class MainOptions {
@@ -12,7 +13,7 @@ public class MainOptions {
             required = true,
             order = 0
     )
-    private Path specPath;
+    private URI specPath;
 
     @Parameter(
             names = {"-i", "--input"},
@@ -41,7 +42,7 @@ public class MainOptions {
         return help;
     }
 
-    public Path getSpecPath() {
+    public URI getSpecPath() {
         return specPath;
     }
 

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/option/MainOptions.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/option/MainOptions.java
@@ -9,7 +9,7 @@ public class MainOptions {
 
     @Parameter(
             names = {"-s", "--spec"},
-            description = "Path to swagger specification.",
+            description = "Path to local or URL to remote swagger specification.",
             required = true,
             order = 0
     )

--- a/swagger-coverage-commandline/src/test/java/com/github/viclovsky/swagger/coverage/Config.java
+++ b/swagger-coverage-commandline/src/test/java/com/github/viclovsky/swagger/coverage/Config.java
@@ -1,6 +1,7 @@
 package com.github.viclovsky.swagger.coverage;
 
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Path;
 
 import static java.util.Optional.ofNullable;
@@ -24,8 +25,8 @@ public class Config {
         return getFile(outputPath).toPath();
     }
 
-    public Path getSpec() {
-        return getFile(specPath).toPath();
+    public URI getSpec() {
+        return URI.create(specPath);
     }
 
     private File getFile(String name) {

--- a/swagger-coverage-commandline/src/test/java/com/github/viclovsky/swagger/coverage/SimpleTest.java
+++ b/swagger-coverage-commandline/src/test/java/com/github/viclovsky/swagger/coverage/SimpleTest.java
@@ -35,12 +35,14 @@ public class SimpleTest {
                 {new Config(CONFIGURATION_FILE, V2_OUTPUT_SWAGGER_COVERAGE_DIR, "v2/petstory_operation_wo_tags.json")},
                 {new Config(CONFIGURATION_FILE, V2_OUTPUT_SWAGGER_COVERAGE_DIR, "v2/petstory_with_x_example.json")},
                 {new Config(CONFIGURATION_FILE, V2_OUTPUT_SWAGGER_COVERAGE_DIR, "v2/petstory_without_parameters.json")},
+                {new Config(CONFIGURATION_FILE, V2_OUTPUT_SWAGGER_COVERAGE_DIR, "https://petstore.swagger.io/v2/swagger.json")},
                 //Swagger v3
                 {new Config(CONFIGURATION_FILE, V3_OUTPUT_SWAGGER_COVERAGE_DIR, "v3/petstory.yaml")},
                 {new Config(CONFIGURATION_FILE, V3_OUTPUT_SWAGGER_COVERAGE_DIR, "v3/petstory_no_tags.yaml")},
                 {new Config(CONFIGURATION_FILE, V3_OUTPUT_SWAGGER_COVERAGE_DIR, "v3/petstory_operation_wo_tags.yaml")},
                 {new Config(CONFIGURATION_FILE, V3_OUTPUT_SWAGGER_COVERAGE_DIR, "v3/petstory_with_x_example.yaml")},
-                {new Config(CONFIGURATION_FILE, V3_OUTPUT_SWAGGER_COVERAGE_DIR, "v3/petstory_without_parameters.yaml")}
+                {new Config(CONFIGURATION_FILE, V3_OUTPUT_SWAGGER_COVERAGE_DIR, "v3/petstory_without_parameters.yaml")},
+                {new Config(CONFIGURATION_FILE, V3_OUTPUT_SWAGGER_COVERAGE_DIR, "https://petstore3.swagger.io/api/v3/openapi.yaml")}
         });
     }
 


### PR DESCRIPTION
The swagger spec can now be parsed from a website, as a lot of projects host their swagger specs somewhere within the dev environments. Therefore, the spec does not have to be downloaded first but can be directly parsed from the server.

Also adjusted the README according to what changed in #91.