### PR TITLE
Fix NPE when coverage output spec not contains any parameters

### DIFF
--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/predicate/DefaultParameterConditionPredicate.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/predicate/DefaultParameterConditionPredicate.java
@@ -21,8 +21,11 @@ public class DefaultParameterConditionPredicate extends ParameterConditionPredic
 
     @Override
     public boolean check(List<Parameter> params, Map<String, ApiResponse> responses) {
-        Optional<Parameter> p = params.stream().filter(ParameterUtils.equalsParam(name, in)).findFirst();
-        return (isEmpty() ^ p.isPresent());
+        if (params != null) {
+            Optional<Parameter> p = params.stream().filter(ParameterUtils.equalsParam(name, in)).findFirst();
+            return (isEmpty() ^ p.isPresent());
+        }
+        return isEmpty();
     }
 
     @Override

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/predicate/DefaultParameterValueConditionPredicate.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/predicate/DefaultParameterValueConditionPredicate.java
@@ -26,11 +26,13 @@ public class DefaultParameterValueConditionPredicate extends ParameterConditionP
 
     @Override
     public boolean check(List<Parameter> params, Map<String, ApiResponse> responses) {
-        Optional<Parameter> p = params.stream().filter(ParameterUtils.equalsParam(name, in)).findFirst();
+        if (params != null) {
+            Optional<Parameter> p = params.stream().filter(ParameterUtils.equalsParam(name, in)).findFirst();
 
-        if (p.isPresent()) {
-            String val = SwaggerSpecificationProcessor.extractValue(p.get());
-            currentValue.add(val);
+            if (p.isPresent()) {
+                String val = SwaggerSpecificationProcessor.extractValue(p.get());
+                currentValue.add(val);
+            }
         }
 
         return currentValue.contains(expectedValue);

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/predicate/NotOnlyParameterListValueConditionPredicate.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/predicate/NotOnlyParameterListValueConditionPredicate.java
@@ -27,10 +27,12 @@ public class NotOnlyParameterListValueConditionPredicate extends ParameterCondit
 
     @Override
     public boolean check(List<Parameter> params, Map<String, ApiResponse> responses) {
-        Optional<Parameter> p = params.stream().filter(ParameterUtils.equalsParam(name, in)).findFirst();
-        if (p.isPresent()) {
-            String val = SwaggerSpecificationProcessor.extractValue(p.get());
-            currentValue.add(val);
+        if (params != null) {
+            Optional<Parameter> p = params.stream().filter(ParameterUtils.equalsParam(name, in)).findFirst();
+            if (p.isPresent()) {
+                String val = SwaggerSpecificationProcessor.extractValue(p.get());
+                currentValue.add(val);
+            }
         }
 
         return true;

--- a/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/predicate/ParameterValueConditionPredicate.java
+++ b/swagger-coverage-commandline/src/main/java/com/github/viclovsky/swagger/coverage/core/predicate/ParameterValueConditionPredicate.java
@@ -25,10 +25,12 @@ public class ParameterValueConditionPredicate extends ParameterConditionPredicat
 
     @Override
     public boolean check(List<Parameter> params, Map<String, ApiResponse> responses) {
-        Optional<Parameter> p = params.stream().filter(ParameterUtils.equalsParam(name, in)).findFirst();
-        if (p.isPresent()) {
-            String val = SwaggerSpecificationProcessor.extractValue(p.get());
-            currentValue.add(val);
+        if (params != null) {
+            Optional<Parameter> p = params.stream().filter(ParameterUtils.equalsParam(name, in)).findFirst();
+            if (p.isPresent()) {
+                String val = SwaggerSpecificationProcessor.extractValue(p.get());
+                currentValue.add(val);
+            }
         }
 
         return true;

--- a/swagger-coverage-commandline/src/test/resources/v2/swagger-coverage-output/empty_parameters.json
+++ b/swagger-coverage-commandline/src/test/resources/v2/swagger-coverage-output/empty_parameters.json
@@ -1,0 +1,17 @@
+{
+  "swagger" : "2.0",
+  "host" : "localhost",
+  "schemes" : [ "http" ],
+  "consumes" : [ "application/json" ],
+  "produces" : [ "" ],
+  "paths" : {
+    "/pet/findByStatus" : {
+      "get" : {
+        "parameters" : [ ],
+        "responses" : {
+          "200" : { }
+        }
+      }
+    }
+  }
+}

--- a/swagger-coverage-commandline/src/test/resources/v3/swagger-coverage-output/empty_parameters.yaml
+++ b/swagger-coverage-commandline/src/test/resources/v3/swagger-coverage-output/empty_parameters.yaml
@@ -1,0 +1,17 @@
+---
+openapi: 3.0.0
+paths:
+  /pet/findByStatus:
+    get:
+      responses:
+        "200":
+          description: ""
+        "400":
+          description: ""
+        "404":
+          description: ""
+servers:
+  - url: http://localhost
+info:
+  version: ""
+  title: ""


### PR DESCRIPTION
Fixing a bug where the absence of parameters in the specification leads to a crash

`java.lang.NullPointerException 
  at com.github.viclovsky.swagger.coverage.core.predicate.DefaultParameterConditionPredicate.check(DefaultParameterConditionPredicate.java:24) 
  at com.github.viclovsky.swagger.coverage.core.predicate.ParameterConditionPredicate.check(ParameterConditionPredicate.java:14) 
  at com.github.viclovsky.swagger.coverage.core.model.SinglePredicateCondition.check(SinglePredicateCondition.java:40) 
  at com.github.viclovsky.swagger.coverage.core.results.builder.prebuilder.CoverageStatisticsBuilder.lambda$null$0(CoverageStatisticsBuilder.java:57)`