### PR TITLE
Fix error on windows when building

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,10 @@ configure(subprojects) {
         options.encoding = "UTF-8"
     }
 
+    tasks.javadoc {
+        options.encoding = "UTF-8"
+    }
+
     tasks.compileTestJava {
         options.encoding = "UTF-8"
         options.compilerArgs.add("-parameters")
@@ -113,4 +117,3 @@ configure(subprojects) {
 repositories {
     mavenCentral()
 }
-


### PR DESCRIPTION
Default charset on windows is Cp1252. LogResultsWriter contains UTF-8 characters. Ex: ✅

Force charset UTF-8 for javadoc